### PR TITLE
fixed Mono.Cecil.AssemblyResolutionException

### DIFF
--- a/StopCrashing.fsx
+++ b/StopCrashing.fsx
@@ -16,6 +16,8 @@ let readerParams binPath =
     let res = DefaultAssemblyResolver ()
     res.AddSearchDirectory "/Library/Frameworks/Xamarin.Mac.framework/Versions/Current/lib/mono"
     res.AddSearchDirectory "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/2.1"
+    res.AddSearchDirectory "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/Xamarin.iOS"
+    res.AddSearchDirectory "/Library/Frameworks/Xamarin.iOS.framework/Versions/Current/lib/mono/2.1/Facades"
     res.AddSearchDirectory (Path.GetDirectoryName (binPath))
     ReaderParameters (AssemblyResolver = res)
 


### PR DESCRIPTION
This resolved the issue for me mentioned here: https://github.com/praeclarum/StopCrashing/issues/4

``` csharp
Mono.Cecil.AssemblyResolutionException: Failed to resolve assembly: 'System.Runtime, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a'
```
